### PR TITLE
feat: component cell supports report tab, outputs as context variable and train-predict/binrule-binsub pipeline

### DIFF
--- a/packages/secretnote/src/components/component-form/table-config/index.tsx
+++ b/packages/secretnote/src/components/component-form/table-config/index.tsx
@@ -21,7 +21,6 @@ const TableConfig = {
         return type.split('.')[1] as IOTypeKind;
       }
     };
-
     const inputKind = getInputKind();
 
     return (

--- a/packages/secretnote/src/components/component-form/table-config/index.tsx
+++ b/packages/secretnote/src/components/component-form/table-config/index.tsx
@@ -1,7 +1,7 @@
 import type { FormInstance } from 'antd';
 import { Input, Form, Select } from 'antd';
 
-import type { SchemaItem } from '../type';
+import type { IOTypeKind, SchemaItem } from '../type';
 import { getByPath } from '../util';
 
 import { TableSelector } from './table-selector';
@@ -15,12 +15,14 @@ const TableConfig = {
     const types = getByPath(root, '$inputTableConfig/types');
     const attrs = getByPath(root, '$inputTableConfig/attrs');
 
-    const getInputType = () => {
+    const getInputKind = () => {
       const type = props.form.getFieldValue(['input', root.id, 'type']);
       if (type) {
-        return type.split('.')[1];
+        return type.split('.')[1] as IOTypeKind;
       }
     };
+
+    const inputKind = getInputKind();
 
     return (
       <Form.Item
@@ -51,7 +53,8 @@ const TableConfig = {
             <Input />
           </Form.Item>
         ))}
-        {getInputType() === 'table' && (
+        {/* Prepare table data_ref selector for table input */}
+        {inputKind === 'table' && (
           <Form.Item
             label="tables"
             name={['input', root.id, 'tables']}
@@ -60,6 +63,19 @@ const TableConfig = {
             dependencies={['input', root.id, 'type']}
           >
             <TableSelector />
+          </Form.Item>
+        )}
+        {/* Prepare model context varibale input for model input */}
+        {/* TODO this is not a table exactly. Extract from table-config? */}
+        {inputKind === 'model' && (
+          <Form.Item
+            label="model"
+            name={['input', root.id, 'model']}
+            labelCol={labelCol}
+            wrapperCol={wrapperCol}
+            dependencies={['input', root.id, 'type']}
+          >
+            <Input />
           </Form.Item>
         )}
       </Form.Item>

--- a/packages/secretnote/src/components/component-form/table-config/index.tsx
+++ b/packages/secretnote/src/components/component-form/table-config/index.tsx
@@ -77,6 +77,19 @@ const TableConfig = {
             <Input />
           </Form.Item>
         )}
+        {/* Prepare rule context varibale input for rule input */}
+        {/* TODO this is not a table exactly. Extract from table-config? */}
+        {inputKind === 'rule' && (
+          <Form.Item
+            label="rule"
+            name={['input', root.id, 'rule']}
+            labelCol={labelCol}
+            wrapperCol={wrapperCol}
+            dependencies={['input', root.id, 'type']}
+          >
+            <Input />
+          </Form.Item>
+        )}
       </Form.Item>
     );
   },

--- a/packages/secretnote/src/components/component-form/type.ts
+++ b/packages/secretnote/src/components/component-form/type.ts
@@ -7,6 +7,8 @@ export type IOType =
   // table
   | 'sf.table.individual'
   | 'sf.table.vertical_table'
+  // binning rule
+  | 'sf.rule.binning'
   // model
   | 'sf.model.ss_sgd'
   | 'sf.model.ss_glm'

--- a/packages/secretnote/src/components/component-form/type.ts
+++ b/packages/secretnote/src/components/component-form/type.ts
@@ -12,7 +12,15 @@ export type IOType =
   | 'sf.model.ss_glm'
   | 'sf.model.sgb'
   | 'sf.model.ss_xgb'
+  // report
   | 'sf.report';
+
+//         String            Delim                                  Part          Remainder
+type Split<S extends string, D extends string> = S extends `${infer P}${D}${infer R}`
+  ? [P, ...Split<R, D>]
+  : [S];
+
+export type IOTypeKind = Split<IOType, '.'>[1];
 
 export type AtomicValue = Record<ValueKey, any>;
 

--- a/packages/secretnote/src/components/component-form/util.ts
+++ b/packages/secretnote/src/components/component-form/util.ts
@@ -132,7 +132,6 @@ const transformSpecToJsonSchema: (spec: ComponentSpec) => SchemaItem = (
     const { name, desc } = attr;
     const type = getRenderType(attr);
     const options = getOptions(attr);
-
     const attrItem: any = {
       id: name,
       type,
@@ -148,13 +147,11 @@ const transformSpecToJsonSchema: (spec: ComponentSpec) => SchemaItem = (
       minimum: getMinimum(attr),
       maximum: getMaximum(attr),
     };
-
     setByPath(json, `properties/attrs/properties/${name}`, attrItem);
   });
 
   (spec.inputs || []).forEach((input) => {
     const inputName = input.name;
-
     const inputItem = {
       id: inputName,
       type: 'object',

--- a/packages/secretnote/src/modules/component-cell/cell-component/component.json
+++ b/packages/secretnote/src/modules/component-cell/cell-component/component.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "comps": [
     {
-      "domain": "feature",
+      "domain": "preprocessing",
       "name": "vert_bin_substitution",
       "desc": "Substitute datasets' value by bin substitution rules.",
       "version": "0.0.1",

--- a/packages/secretnote/src/modules/component-cell/cell-component/component.json
+++ b/packages/secretnote/src/modules/component-cell/cell-component/component.json
@@ -260,25 +260,18 @@
       ],
       "inputs": [
         {
-          "name": "labels",
-          "desc": "Input table with labels",
+          "name": "in_ds",
+          "desc": "Input table with predictions.",
           "types": ["sf.table.vertical_table", "sf.table.individual"],
           "attrs": [
             {
-              "name": "col",
-              "desc": "The column name to use in the dataset. If not provided, the label of dataset will be used by default.",
+              "name": "label",
+              "desc": "Label column name of input data.",
               "colMaxCntInclusive": "1"
-            }
-          ]
-        },
-        {
-          "name": "predictions",
-          "desc": "Input table with predictions",
-          "types": ["sf.table.vertical_table", "sf.table.individual"],
-          "attrs": [
+            },
             {
-              "name": "col",
-              "desc": "The column name to use in the dataset. If not provided, the label of dataset will be used by default.",
+              "name": "prediction",
+              "desc": "Prediction column name of input data.",
               "colMaxCntInclusive": "1"
             }
           ]
@@ -347,25 +340,18 @@
       ],
       "inputs": [
         {
-          "name": "labels",
-          "desc": "Input table with labels.",
-          "types": ["sf.table.vertical_table", "sf.table.individual"],
-          "attrs": [
-            {
-              "name": "col",
-              "desc": "The column name to use in the dataset. If not provided, the label of dataset will be used by default.",
-              "colMaxCntInclusive": "1"
-            }
-          ]
-        },
-        {
-          "name": "predictions",
+          "name": "in_ds",
           "desc": "Input table with predictions.",
           "types": ["sf.table.vertical_table", "sf.table.individual"],
           "attrs": [
             {
-              "name": "col",
-              "desc": "The column name to use in the dataset. If not provided, the label of dataset will be used by default.",
+              "name": "label",
+              "desc": "Label column name of input data.",
+              "colMaxCntInclusive": "1"
+            },
+            {
+              "name": "prediction",
+              "desc": "Prediction column name of input data.",
               "colMaxCntInclusive": "1"
             }
           ]
@@ -408,7 +394,7 @@
       "domain": "ml.predict",
       "name": "sgb_predict",
       "desc": "Predict using SGB model.",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "attrs": [
         {
           "name": "receiver",
@@ -1061,6 +1047,11 @@
               "desc": "Label of train dataset.",
               "colMinCntInclusive": "1",
               "colMaxCntInclusive": "1"
+            },
+            {
+              "name": "feature_selects",
+              "desc": "Features to be trained with.",
+              "colMinCntInclusive": "1"
             }
           ]
         }
@@ -1270,6 +1261,11 @@
               "desc": "Label of train dataset.",
               "colMinCntInclusive": "1",
               "colMaxCntInclusive": "1"
+            },
+            {
+              "name": "feature_selects",
+              "desc": "Features to be trained with.",
+              "colMinCntInclusive": "1"
             }
           ]
         }
@@ -1279,6 +1275,11 @@
           "name": "output_model",
           "desc": "Output model.",
           "types": ["sf.model.ss_glm"]
+        },
+        {
+          "name": "output_report",
+          "desc": "Output report.",
+          "types": ["sf.report"]
         }
       ]
     },
@@ -1412,6 +1413,11 @@
               "desc": "Label of train dataset.",
               "colMinCntInclusive": "1",
               "colMaxCntInclusive": "1"
+            },
+            {
+              "name": "feature_selects",
+              "desc": "Features to be trained with.",
+              "colMinCntInclusive": "1"
             }
           ]
         }

--- a/packages/secretnote/src/modules/component-cell/cell-component/component.json
+++ b/packages/secretnote/src/modules/component-cell/cell-component/component.json
@@ -663,7 +663,14 @@
         {
           "name": "feature_dataset",
           "desc": "Input vertical table.",
-          "types": ["sf.table.vertical_table"]
+          "types": ["sf.table.vertical_table"],
+          "attrs": [
+            {
+              "name": "saved_features",
+              "desc": "Features to save into output pred file.",
+              "colMinCntInclusive": "1"
+            }
+          ]
         }
       ],
       "outputs": [
@@ -1599,6 +1606,11 @@
           "types": ["sf.table.vertical_table"],
           "attrs": [
             {
+              "name": "feature_selects",
+              "desc": "Features to be trained with.",
+              "colMinCntInclusive": "1"
+            },
+            {
               "name": "label",
               "desc": "Label of train dataset.",
               "colMinCntInclusive": "1",
@@ -1616,7 +1628,7 @@
       ]
     },
     {
-      "domain": "preprocessing",
+      "domain": "data_filter",
       "name": "feature_filter",
       "desc": "Drop features from the dataset.",
       "version": "0.0.1",
@@ -1642,7 +1654,7 @@
       ]
     },
     {
-      "domain": "preprocessing",
+      "domain": "data_prep",
       "name": "psi",
       "desc": "PSI between two parties.",
       "version": "0.0.1",
@@ -1733,7 +1745,7 @@
       ]
     },
     {
-      "domain": "preprocessing",
+      "domain": "data_prep",
       "name": "train_test_split",
       "desc": "Split datasets into random train and test subsets.\n- Please check: https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html",
       "version": "0.0.1",

--- a/packages/secretnote/src/modules/component-cell/cell-component/index.less
+++ b/packages/secretnote/src/modules/component-cell/cell-component/index.less
@@ -47,6 +47,8 @@
 
       .sf-component-report {
         height: 400px;
+        padding-bottom: 1em;
+        overflow-y: scroll;
       }
 
       .sf-component-log {

--- a/packages/secretnote/src/modules/component-cell/cell-component/index.tsx
+++ b/packages/secretnote/src/modules/component-cell/cell-component/index.tsx
@@ -1,7 +1,7 @@
 import type { IOutput } from '@difizen/libro-jupyter';
 import { Tabs, Empty, Spin, Table, Descriptions } from 'antd';
 import type { TabsProps, TableProps, DescriptionsProps } from 'antd';
-import { forwardRef, type ForwardedRef, useMemo, useEffect } from 'react';
+import { forwardRef, type ForwardedRef, useMemo } from 'react';
 
 import { ComponentForm } from '@/components/component-form';
 import type { ComponentSpec, Value } from '@/components/component-form';

--- a/packages/secretnote/src/modules/component-cell/model.ts
+++ b/packages/secretnote/src/modules/component-cell/model.ts
@@ -35,7 +35,7 @@ type DescriptionsChild = {
     items: {
       name: string;
       type: string;
-      value: Value; // {protobuf type -> value}[]
+      value: Value; // {protobuf type -> value}
     }[];
   };
 };

--- a/packages/secretnote/src/modules/component-cell/model.ts
+++ b/packages/secretnote/src/modules/component-cell/model.ts
@@ -15,6 +15,31 @@ import { inject, transient } from '@difizen/mana-app';
 import type { Event } from '@difizen/mana-common';
 import type { Value } from '@/components/component-form';
 
+type TableChild = {
+  type: 'table';
+  table: {
+    headers: {
+      name: string;
+      type: string;
+    }[];
+    rows: {
+      name: string;
+      items: Value[]; // value of this row, {protobuf type -> value}[]
+    }[];
+  };
+};
+
+type DescriptionsChild = {
+  type: 'descriptions';
+  descriptions: {
+    items: {
+      name: string;
+      type: string;
+      value: Value; // {protobuf type -> value}[]
+    }[];
+  };
+};
+
 // type of sf.report from secretflow component
 export type SFReport = {
   name: string;
@@ -27,19 +52,7 @@ export type SFReport = {
     // @see https://github.com/secretflow/spec/blob/main/secretflow/spec/v1/report.proto
     tabs: {
       divs: {
-        children: {
-          type: 'table';
-          table: {
-            headers: {
-              name: string;
-              type: string;
-            }[];
-            rows: {
-              name: string;
-              items: Value[]; // value of this row, {protobuf type -> value}[]
-            }[];
-          };
-        }[];
+        children: (TableChild | DescriptionsChild)[];
       }[];
     }[];
   };
@@ -96,7 +109,7 @@ export class ComponentCellModel
   outputs: IOutput[] = [];
 
   @prop()
-  report: ComponentReport | null;
+  report: ComponentReport | null; // data for the Report tab
 
   constructor(@inject(CellOptions) options: CellOptions) {
     super(options);

--- a/packages/secretnote/src/modules/component-cell/model.ts
+++ b/packages/secretnote/src/modules/component-cell/model.ts
@@ -13,6 +13,47 @@ import {
 import { Emitter, prop } from '@difizen/mana-app';
 import { inject, transient } from '@difizen/mana-app';
 import type { Event } from '@difizen/mana-common';
+import type { Value } from '@/components/component-form';
+
+// type of sf.report from secretflow component
+export type SFReport = {
+  name: string;
+  type: 'sf.report';
+  systemInfo: Value;
+  meta: {
+    '@type': 'type.googleapis.com/secretflow.spec.v1.Report';
+    name: string;
+    desc: string;
+    // @see https://github.com/secretflow/spec/blob/main/secretflow/spec/v1/report.proto
+    tabs: {
+      divs: {
+        children: {
+          type: 'table';
+          table: {
+            headers: {
+              name: string;
+              type: string;
+            }[];
+            rows: {
+              name: string;
+              items: Value[]; // value of this row, {protobuf type -> value}[]
+            }[];
+          };
+        }[];
+      }[];
+    }[];
+  };
+};
+
+// type of necessary data for the Report tab
+export type ComponentReport = {
+  name: string; // name
+  metaName: string; // .meta.name
+  metaDesc: string; // .meta.desc
+  metaColumnNames: string[]; // column names of the table
+  metaRowNames: string[]; // row names of the table
+  metaRowItems: Value[]; // table cells
+};
 
 export interface ComponentMetadata {
   component: {
@@ -54,6 +95,9 @@ export class ComponentCellModel
   @prop()
   outputs: IOutput[] = [];
 
+  @prop()
+  report: ComponentReport | null;
+
   constructor(@inject(CellOptions) options: CellOptions) {
     super(options);
     this.executing = false;
@@ -61,6 +105,7 @@ export class ComponentCellModel
     this.msgChangeEmitter = new Emitter<any>();
     this.metadata = options.cell.metadata || {};
     this.outputs = (options.cell.outputs as IOutput[]) || [];
+    this.report = (options.cell.report as ComponentReport) || null;
     this.value = concatMultilineString(options.cell.source);
   }
 


### PR DESCRIPTION
- `sf.report` output now sends to the frontend by Comm message and displays on Report tab
- model training now exposes trained model and other outputs to context variables and can be used in model prediction components
- so as binning rule generators expose binning rule and can be referred to in `vert_bin_substitution`
- refactored `component.json` schema according to latest secretflow `sf.components.entry.COMP_MAP` and test cases
- generated Python code narrows into its own scope
- a notebook for testing all components in secretflow document is prepared