### PR TITLE
secretNote本地启动状态bugfix

### DIFF
--- a/docker/secretnote-sf-sim/docker-compose.yml
+++ b/docker/secretnote-sf-sim/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - SELF_PARTY=alice
     ports:
       - 8090:8888
+    user: root
+    command: sh -c "chown -R secretnote:secretnote /home/secretnote/workspace"
     volumes:
       - ./alice:/home/secretnote/workspace
 
@@ -18,5 +20,7 @@ services:
       - SELF_PARTY=bob
     ports:
       - 8092:8888
+    user: root
+    command: sh -c "chown -R secretnote:secretnote /home/secretnote/workspace"
     volumes:
       - ./bob:/home/secretnote/workspace


### PR DESCRIPTION
容器启动前使用容器内部root权限修改通过volume挂载进来的外部宿主机目录属组，确保docker-compose场景下容器内部属组一致

测试验证截图：
![622ba0009a223d27a379e5824a640fa](https://github.com/user-attachments/assets/34b5332c-187c-46ae-8fcf-12f0166e65b3)
